### PR TITLE
added -std=gnu89 for ANSI C standard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,17 @@ jobs:
         version: ['1']  # Test against LTS and current minor release
         os: [ubuntu-latest, macOS-latest, windows-latest] # macOS-latest, windows-latest
         arch: [x64]
+        include:
+           - os: macOS-latest
+             arch: aarch64
+             version: 1        
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -102,7 +102,7 @@ function _build_concorde()
     cd(concorde_src_dir)
     
     macflag = Sys.isapple() ? "--host=darwin" : ""
-    cflags = "-fPIC -O2 -g"
+    cflags = "-std=gnu89 -fPIC -O2 -g"
     run(`bash -c "CFLAGS='$(cflags)' ./configure --with-qsopt=$(qsopt_dir) $(macflag)"`)
     run(`make clean`)
     run(`make`)


### PR DESCRIPTION
Concorde was written in ANSI C.  In Line 873 of `configure` file in the Concorde distribution:
```
main(){return(0);}
```
which is part of a test program during configure.  In modern C, especially with gcc in recent macOS, such typeless main functions are prohibited. 

To allow this, this PR added a CFLAG of `std=gnu89`.

