### PR TITLE
Minor fix for 7zip-related error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [master]
+    branches: [max_fix]
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [max_fix]
+    branches: [mac_fix]
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:


### PR DESCRIPTION
Fixed an issue where tests on Windows failed due to a missing `7z.exe` executable:  

`ERROR: LoadError: IOError: could not spawn `'C:\hostedtoolcache\windows\julia\1.11.4\x64\bin\..\libexec\7z.exe' x 'D:\a\Concorde.jl\Concorde.jl\deps\win_dir\concorde.exe.gz' -y '-oD:\a\Concorde.jl\Concorde.jl\deps\win_dir'`: no such file or directory (ENOENT)`
This update ensures that tests pass on Windows by handling the missing executable.  

> **Note:** The current implementation installs 7zip if a local installation is not found. I can modify the code to throw an error instead of installing it if preferred.
 